### PR TITLE
Update page.cpp

### DIFF
--- a/lab8/src/3/src/boot/page.cpp
+++ b/lab8/src/3/src/boot/page.cpp
@@ -1,36 +1,41 @@
 #include "os_constant.h"
+#include <stdint.h>
 
 extern "C" void open_page_mechanism()
 {
-    // 页目录表指针
-    int *directory = (int *)PAGE_DIRECTORY;
-    //线性地址0~4MB对应的页表
-    int *page = (int *)(PAGE_DIRECTORY + PAGE_SIZE);
+    // 使用 uintptr_t 处理地址，保证类型安全
+    uintptr_t page_directory_base = PAGE_DIRECTORY;
+    uintptr_t page_table_base = PAGE_DIRECTORY + PAGE_SIZE;
 
-    
+    // 将地址转换为指针
+    int *directory = (int *)page_directory_base;
+    int *page = (int *)page_table_base;
+
+    // 页目录表和页表项的数量
     int entryNum = PAGE_SIZE / sizeof(int);
-    for(int i = 0; i < entryNum; ++i ) {
-        // 初始化页目录表
-        directory[i] = 0;
-        // 初始化线性地址0~4MB对应的页表
-        page[i] = 0;
+
+    // 初始化页目录表和页表
+    for (int i = 0; i < entryNum; ++i) {
+        directory[i] = 0;  // 初始化页目录表
+        page[i] = 0;       // 初始化线性地址 0~4MB 对应的页表
     }
 
     int address = 0;
-    // 将线性地址0~1MB恒等映射到物理地址0~1MB
-    for (int i = 0; i < 256; ++i)
-    {
-        // U/S = 1, R/W = 1, P = 1
+
+    // 将线性地址 0~1MB 恒等映射到物理地址 0~1MB
+    for (int i = 0; i < 256; ++i) {
+        // 设置页表项，U/S = 1, R/W = 1, P = 1
         page[i] = address | 0x7;
         address += PAGE_SIZE;
     }
 
     // 初始化页目录项
+    // 映射 0~1MB
+    directory[0] = (uintptr_t)page | 0x07;
 
-    // 0~1MB
-    directory[0] = ((int)page) | 0x07;
-    // 3GB的内核空间
+    // 映射 3GB 的内核空间
     directory[768] = directory[0];
-    // 最后一个页目录项指向页目录表
-    directory[1023] = ((int)directory) | 0x7;
+
+    // 设置页目录最后一项指向页目录表，用于递归映射
+    directory[1023] = (uintptr_t)directory | 0x07;
 }


### PR DESCRIPTION
**Issue: Unsafe Type Conversion**  
Hello! This is Jason from Microsoft.
Direct type casting of `PAGE_DIRECTORY` and `PAGE_DIRECTORY + PAGE_SIZE` to `(int *)` may lead to undefined behavior if these values are incorrect or not properly aligned. Using such direct casts lacks type safety and may cause runtime errors.  

**Suggestion:**  
Instead of directly casting, use `uintptr_t` or a similar unsigned integer type for handling addresses. This ensures proper type safety and makes the code more robust.  

**Proposed Improvement:**  
```cpp
uintptr_t page_directory_base = PAGE_DIRECTORY;
uintptr_t page_table_base = PAGE_DIRECTORY + PAGE_SIZE;
int *page_directory = (int *)page_directory_base;
int *page_table = (int *)page_table_base;
```

This change enhances code safety and readability by separating the raw address handling from pointer assignment.